### PR TITLE
Don't require asciidoctor ruby module when doing cli call

### DIFF
--- a/Commands/Preview Document (Asciidoctor).tmCommand
+++ b/Commands/Preview Document (Asciidoctor).tmCommand
@@ -8,7 +8,6 @@
 	<string>#!/usr/bin/env ruby
 
 require 'fileutils'
-require 'asciidoctor'
 
 f = ENV['TM_FILEPATH']
 fdir = File.dirname(f)
@@ -19,6 +18,9 @@ f2 = f2 + fbase + '.html'
 
 
 # this is what we would want to say in ruby; note that unsafe is necessary
+# 
+# require 'asciidoctor'
+# 
 # Asciidoctor.render_file(f, {:header_footer =&gt; true, :safe =&gt; 'unsafe', :to_file =&gt; f2})
 
 # however, TextMate gives us nice output if we pass through the command-line

--- a/Commands/Preview Document Book (Asciidoctor).tmCommand
+++ b/Commands/Preview Document Book (Asciidoctor).tmCommand
@@ -8,7 +8,6 @@
 	<string>#!/usr/bin/env ruby
 
 require 'fileutils'
-require 'asciidoctor'
 
 f = ENV['TM_FILEPATH']
 fdir = File.dirname(f)
@@ -20,6 +19,9 @@ f2 = f2 + fbase + '.html'
 # exactly the same as Preview Document (Asciidoctor) except for -dbook specification
 
 # this is what we would want to say in ruby; note that unsafe is necessary
+# 
+# require 'asciidoctor'
+# 
 # Asciidoctor.render_file(f, {:header_footer =&gt; true, :safe =&gt; 'unsafe', :to_file =&gt; f2})
 
 # however, TextMate gives us nice output if we pass through the command-line


### PR DESCRIPTION
I got an import error due to asciidoctor being required even though it it not used in the preview command so I moved the call to the comment below.